### PR TITLE
fix >=python3.10 Iterables import error

### DIFF
--- a/pykin/utils/transform_utils.py
+++ b/pykin/utils/transform_utils.py
@@ -1,6 +1,9 @@
 import numpy as np
 import math
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 
 def vector_norm(data, axis=None, out=None):


### PR DESCRIPTION
Fixes `ImportError: cannot import name 'Iterable' from 'collections'` for python >= 3.10